### PR TITLE
Parse time from IdP so it doesn't fail when passed a string instead of an int

### DIFF
--- a/lib/rack/saml.rb
+++ b/lib/rack/saml.rb
@@ -131,7 +131,7 @@ module Rack
           return true if sid.nil? # no sid check
           return true if session['sid'] == sid # sid check
         else
-          if Time.now < Time.at(session['expired_at']) # before expiration
+          if Time.now < Time.parse(session['expired_at']) # before expiration
             return true if sid.nil? # no sid check
             return true if session['sid'] == sid # sid check
           end


### PR DESCRIPTION
Apologies if I should handle this another waym but I can't work it out if I can. My IdP returns the "expires_on" as a string with the date and time in it, so it fails when rack-saml expects an integer. This change should work in both situations.
