### PR TITLE
adds explicit conversion of session[:expire] to string

### DIFF
--- a/lib/rack/saml.rb
+++ b/lib/rack/saml.rb
@@ -131,7 +131,7 @@ module Rack
           return true if sid.nil? # no sid check
           return true if session['sid'] == sid # sid check
         else
-          if Time.now < Time.parse(session['expired_at']) # before expiration
+          if Time.now < Time.parse(session['expired_at'].to_s) # before expiration
             return true if sid.nil? # no sid check
             return true if session['sid'] == sid # sid check
           end


### PR DESCRIPTION
Fixes an issue I had with a Time object throwing a parse error
