### PR TITLE
Kerlin - process encrypted response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+before_install:
+  - gem update --system
+  - gem update bundler

--- a/config/rack-saml.yml
+++ b/config/rack-saml.yml
@@ -7,3 +7,5 @@ shib_app_id: default
 shibb_ds: https://localhost/discovery/WAYF
 allowed_clock_drift: 60
 validation_error: true
+certificate_path: config/cert/server_development.crt
+private_key_path: config/cert/server_development.key

--- a/config/rack-saml.yml
+++ b/config/rack-saml.yml
@@ -7,5 +7,5 @@ shib_app_id: default
 shibb_ds: https://localhost/discovery/WAYF
 allowed_clock_drift: 60
 validation_error: true
-certificate_path: config/cert/server_development.crt
-private_key_path: config/cert/server_development.key
+sp_cert: config/cert/development_cert.pem
+sp_key: config/cert/development_key.pem

--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -7,6 +7,8 @@ module Rack
         settings = OneLogin::RubySaml::Settings.new
         settings.assertion_consumer_service_url = @config['assertion_consumer_service_uri']
         settings.issuer = @config['saml_sp']
+        settings.certificate = IO::File.open(@config['certificate_path'], "r").read if @config['certificate_path']
+        settings.private_key = IO::File.open(@config['private_key_path'], "r").read if @config['private_key_path']
         settings.idp_sso_target_url = @metadata['saml2_http_redirect']
         settings.idp_cert = @metadata['certificate']
         settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"

--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -7,8 +7,16 @@ module Rack
         settings = OneLogin::RubySaml::Settings.new
         settings.assertion_consumer_service_url = @config['assertion_consumer_service_uri']
         settings.issuer = @config['saml_sp']
-        settings.certificate = IO::File.open(@config['certificate_path'], "r").read if @config['certificate_path']
-        settings.private_key = IO::File.open(@config['private_key_path'], "r").read if @config['private_key_path']
+        if ENV['SP_CERT]']
+          settings.certificate = ENV['SP_CERT']
+        elsif @config['sp_cert']
+          settings.certificate = IO::File.open(@config['sp_cert'], 'r').read
+        end
+        if ENV['SP_KEY']
+          settings.private_key = ENV['SP_KEY']
+        elsif @config['sp_key']
+          settings.private_key = IO::File.open(@config['sp_key'], 'r').read
+        end
         settings.idp_sso_target_url = @metadata['saml2_http_redirect']
         settings.idp_cert = @metadata['certificate']
         settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"

--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -7,7 +7,7 @@ module Rack
         settings = OneLogin::RubySaml::Settings.new
         settings.assertion_consumer_service_url = @config['assertion_consumer_service_uri']
         settings.issuer = @config['saml_sp']
-        if ENV['SP_CERT]']
+        if ENV['SP_CERT']
           settings.certificate = ENV['SP_CERT']
         elsif @config['sp_cert']
           settings.certificate = IO::File.open(@config['sp_cert'], 'r').read

--- a/lib/rack/saml/response/onelogin_response.rb
+++ b/lib/rack/saml/response/onelogin_response.rb
@@ -9,9 +9,9 @@ module Rack
       def initialize(request, config, metadata)
         super(request, config, metadata)
         @response = OneLogin::RubySaml::Response.new(@request.params['SAMLResponse'], {
-          :allowed_clock_drift => config['allowed_clock_drift']
+          :allowed_clock_drift => config['allowed_clock_drift'],
+          :settings => saml_settings
         })
-        @response.settings = saml_settings
       end
 
       def is_valid?


### PR DESCRIPTION
Changes to allow a rails SP using devise, omniauth-shibboleth, and rack-saml to authenticate with idp.testshib.org