### PR TITLE
Add ability to configure want_assertions_encrypted

### DIFF
--- a/config/rack-saml.yml
+++ b/config/rack-saml.yml
@@ -9,3 +9,4 @@ allowed_clock_drift: 60
 validation_error: true
 sp_cert: config/cert/development_cert.pem
 sp_key: config/cert/development_key.pem
+want_assertions_encrypted: false

--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -20,6 +20,7 @@ module Rack
         settings.idp_sso_target_url = @metadata['saml2_http_redirect']
         settings.idp_cert = @metadata['certificate']
         settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+        settings.security[:want_assertions_encrypted] = @config['want_assertions_encrypted']
         #settings.authn_context = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
         settings
       end


### PR DESCRIPTION
This PR adds ability to configure `want_assertions_encrypted` security option used by ruby-saml: 
https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/metadata.rb#L49
to modify the metadata in order to introduce `"use" => "encryption"` attribute. 

