### PR TITLE
Fix error reading cert files

### DIFF
--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -10,12 +10,12 @@ module Rack
         if ENV['SP_CERT']
           settings.certificate = ENV['SP_CERT']
         elsif @config['sp_cert']
-          settings.certificate = IO::File.open(@config['sp_cert'], 'r').read
+          settings.certificate = ::File.open(@config['sp_cert'], 'r').read
         end
         if ENV['SP_KEY']
           settings.private_key = ENV['SP_KEY']
         elsif @config['sp_key']
-          settings.private_key = IO::File.open(@config['sp_key'], 'r').read
+          settings.private_key = ::File.open(@config['sp_key'], 'r').read
         end
         settings.idp_sso_target_url = @metadata['saml2_http_redirect']
         settings.idp_cert = @metadata['certificate']


### PR DESCRIPTION
Use ::File to reference Ruby top level File.open(), don't want Rack::File, and IO:File is just wrong.