### PR TITLE
Additional settings in onelogin_setting.rb

### DIFF
--- a/lib/rack/saml/misc/onelogin_setting.rb
+++ b/lib/rack/saml/misc/onelogin_setting.rb
@@ -21,6 +21,8 @@ module Rack
         settings.idp_cert = @metadata['certificate']
         settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
         settings.security[:want_assertions_encrypted] = @config['want_assertions_encrypted']
+        settings.security[:want_assertions_signed] = @config['want_assertions_signed']
+        settings.security[:authn_requests_signed] = @config['authn_requests_signed']
         #settings.authn_context = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
         settings
       end


### PR DESCRIPTION
Adding setting to agree with changes in ruby-saml 1.3.1 and later. See https://github.com/onelogin/ruby-saml/issues/306 and https://github.com/onelogin/ruby-saml/commit/6c5413134aec1aa70de67a66c64f22b76ae52574
Previously, settings.security[:want_assertions_signed] was set to true by ruby-saml/metadata.rb when the metadata.yml contained an idp certificate. Now it must be set explicitly. This change allows it to be set in rack-saml.yml with want_assertions_signed: true
Also passing the setting :authn_requests_signed